### PR TITLE
Remove null returns from number parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "name": "sussol-utilities",
   "main": "lib/index.js",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "license": "MIT",
   "description": "Utility javascript code for use across Sussol projects",
   "repository": {

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -4,7 +4,6 @@
 * @return {integer}               The positive integer represented by numberString, or 0
 */
 export function parsePositiveInteger(numberString) {
-  if (!numberString || numberString.length < 1) return null;
   const number = parseFloat(numberString);
   if (isNaN(number)) return 0; // Invalid strings become 0
   return Math.max(Math.round(number), 0); // Negative numbers become 0
@@ -15,7 +14,6 @@ export function parsePositiveInteger(numberString) {
 * @return {integer}               The positive float represented by numberString, or 0
 */
 export function parsePositiveFloat(numberString) {
-  if (!numberString || numberString.length < 1) return null;
   const number = parseFloat(numberString);
   if (isNaN(number) || number < 0) return 0; // Invalid strings or negatives become 0
   return number;


### PR DESCRIPTION
If null or '' was given to the parser it would return null rather than 0. This is rather different from how NaN was being treated. Should now give parsed positive number, or 0 in all other cases.